### PR TITLE
Respect peer's connection-level flow control

### DIFF
--- a/server_test.go
+++ b/server_test.go
@@ -1408,7 +1408,11 @@ func TestServer_Response_LargeWrite(t *testing.T) {
 		if err := st.fr.WriteWindowUpdate(1, size); err != nil {
 			t.Fatal(err)
 		}
-
+		// Give the handler quote to write to connection-level
+		// window as well
+		if err := st.fr.WriteWindowUpdate(0, size); err != nil {
+			t.Fatal(err)
+		}
 		hf := st.wantHeaders()
 		if hf.StreamEnded() {
 			t.Fatal("unexpected END_STREAM flag")


### PR DESCRIPTION
Previously connection-level flow control is not respected at all.
Only stream-level one is used.  Also there are 3 bugs with regard to
flow control.  First one is that flow window is not drained when
allowed quota is greater than or equal to the number of bytes to
write.  Second one is that 0 length DATA frame cannot be sent when
allowed quota == 0.  Third one is that if DATA frmae is processed in
"fast path", flow control is not ignored.  This commit adds
connection-flow control enforcement and fixes these bugs.
