### PR TITLE
Fix several issues found by 'go vet'

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,4 +15,5 @@ Gabriel Aszalos <gabriel.aszalos@gmail.com> github=gbbr
 Google, Inc.
 Keith Rarick <kr@xph.us> github=kr
 Matthew Keenan <tank.en.mate@gmail.com> <github@mattkeenan.net> github=mattkeenan
+Matt Layher <mdlayher@gmail.com> github=mdlayher
 Tatsuhiro Tsujikawa <tatsuhiro.t@gmail.com> github=tatsuhiro-t

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -15,4 +15,5 @@ Daniel Morsing <daniel.morsing@gmail.com> github=DanielMorsing
 Gabriel Aszalos <gabriel.aszalos@gmail.com> github=gbbr
 Keith Rarick <kr@xph.us> github=kr
 Matthew Keenan <tank.en.mate@gmail.com> <github@mattkeenan.net> github=mattkeenan
+Matt Layher <mdlayher@gmail.com> github=mdlayher
 Tatsuhiro Tsujikawa <tatsuhiro.t@gmail.com> github=tatsuhiro-t

--- a/errors_test.go
+++ b/errors_test.go
@@ -21,7 +21,7 @@ func TestErrCodeString(t *testing.T) {
 	for i, tt := range tests {
 		got := tt.err.String()
 		if got != tt.want {
-			t.Errorf("%i. Error = %q; want %q", i, got, tt.want)
+			t.Errorf("%d. Error = %q; want %q", i, got, tt.want)
 		}
 	}
 }

--- a/frame_test.go
+++ b/frame_test.go
@@ -69,7 +69,7 @@ func TestWriteData(t *testing.T) {
 		t.Fatalf("got %T; want *DataFrame", f)
 	}
 	if !bytes.Equal(df.Data(), data) {
-		t.Errorf("got %q; want %q", df.Data, data)
+		t.Errorf("got %q; want %q", df.Data(), data)
 	}
 	if f.Header().Flags&1 == 0 {
 		t.Errorf("didn't see END_STREAM flag")
@@ -344,7 +344,7 @@ func TestWriteSettings(t *testing.T) {
 		got = append(got, s)
 		valBack, ok := sf.Value(s.ID)
 		if !ok || valBack != s.Val {
-			t.Errorf("Value(%d) = %v, %v; want %v, true", s.ID, valBack, ok)
+			t.Errorf("Value(%d) = %v, %v; want %v, true", s.ID, valBack, ok, s.Val)
 		}
 		return nil
 	})

--- a/hpack/encode_test.go
+++ b/hpack/encode_test.go
@@ -81,7 +81,7 @@ func TestEncoderWriteField(t *testing.T) {
 		}
 		_, err := d.Write(buf.Bytes())
 		if err != nil {
-			t.Error("%d. Decoder Write = %v", i, err)
+			t.Errorf("%d. Decoder Write = %v", i, err)
 		}
 		if !reflect.DeepEqual(got, tt.hdrs) {
 			t.Errorf("%d. Decoded %+v; want %+v", i, got, tt.hdrs)
@@ -322,10 +322,9 @@ func TestEncoderSetMaxDynamicTableSizeLimit(t *testing.T) {
 		t.Errorf("e.dynTab.maxSize = %v; want %v", got, want)
 	}
 	if got, want := e.maxSizeLimit, uint32(8192); got != want {
-		t.Errorf("e.maxSizeLimit = %v; want %v", got, want);
+		t.Errorf("e.maxSizeLimit = %v; want %v", got, want)
 	}
 }
-
 
 func removeSpace(s string) string {
 	return strings.Replace(s, " ", "", -1)

--- a/hpack/hpack_test.go
+++ b/hpack/hpack_test.go
@@ -127,18 +127,18 @@ func TestDynamicTableAt(t *testing.T) {
 	d := NewDecoder(4096, nil)
 	at := d.mustAt
 	if got, want := at(2), (pair(":method", "GET")); got != want {
-		t.Errorf("at(2) = %q; want %q", got, want)
+		t.Errorf("at(2) = %v; want %v", got, want)
 	}
 	d.dynTab.add(pair("foo", "bar"))
 	d.dynTab.add(pair("blake", "miz"))
 	if got, want := at(len(staticTable)+1), (pair("blake", "miz")); got != want {
-		t.Errorf("at(dyn 1) = %q; want %q", got, want)
+		t.Errorf("at(dyn 1) = %v; want %v", got, want)
 	}
 	if got, want := at(len(staticTable)+2), (pair("foo", "bar")); got != want {
-		t.Errorf("at(dyn 2) = %q; want %q", got, want)
+		t.Errorf("at(dyn 2) = %v; want %v", got, want)
 	}
 	if got, want := at(3), (pair(":method", "POST")); got != want {
-		t.Errorf("at(3) = %q; want %q", got, want)
+		t.Errorf("at(3) = %v; want %v", got, want)
 	}
 }
 
@@ -196,7 +196,7 @@ func TestDynamicTableSizeEvict(t *testing.T) {
 		t.Fatalf("after setMaxSize, size = %d; want %d", d.dynTab.size, want)
 	}
 	if got, want := d.mustAt(len(staticTable)+1), (pair("foo", "bar")); got != want {
-		t.Errorf("at(dyn 1) = %q; want %q", got, want)
+		t.Errorf("at(dyn 1) = %v; want %v", got, want)
 	}
 	add(pair("long", strings.Repeat("x", 500)))
 	if want := uint32(0); d.dynTab.size != want {

--- a/server_test.go
+++ b/server_test.go
@@ -505,7 +505,7 @@ func TestServer_Request_Get_PathSlashes(t *testing.T) {
 		})
 	}, func(r *http.Request) {
 		if r.RequestURI != "/%2f/" {
-			t.Errorf("RequestURI = %q; want /%2f/", r.RequestURI)
+			t.Errorf("RequestURI = %q; want /%%2f/", r.RequestURI)
 		}
 		if r.URL.Path != "///" {
 			t.Errorf("URL.Path = %q; want ///", r.URL.Path)
@@ -1896,7 +1896,7 @@ func TestServer_Response_ManyHeaders_With_Continuation(t *testing.T) {
 			}
 		}
 		if n < 5 {
-			t.Errorf("Only got %d CONTINUATION frames; expected 5+ (currently 6)")
+			t.Errorf("Only got %d CONTINUATION frames; expected 5+ (currently 6)", n)
 		}
 	})
 }


### PR DESCRIPTION
I ran `go vet ./...` and have fixed all of the following issues:

```
[zsh|matt@nerr-2]:~/git/go/src/github.com/bradfitz/http2 0 (master) ± go vet ./...
errors_test.go:24: unrecognized printf verb 'i'
frame_test.go:72: arg df.Data for printf verb %q of wrong type: func() []byte
frame_test.go:347: missing argument for Errorf("%v"): format reads arg 4, have only 3 args
server_test.go:508: missing argument for Errorf("%2f"): format reads arg 2, have only 1 args
server_test.go:1899: missing argument for Errorf("%d"): format reads arg 1, have only 0 args
exit status 1
hpack/encode_test.go:84: possible formatting directive in Error call
hpack/hpack_test.go:130: arg got for printf verb %q of wrong type: hpack.HeaderField
hpack/hpack_test.go:135: arg got for printf verb %q of wrong type: hpack.HeaderField
hpack/hpack_test.go:138: arg got for printf verb %q of wrong type: hpack.HeaderField
hpack/hpack_test.go:141: arg got for printf verb %q of wrong type: hpack.HeaderField
hpack/hpack_test.go:199: arg got for printf verb %q of wrong type: hpack.HeaderField
exit status 1
```

In addition, I have already signed the Google Individual CLA under the same email address: mdlayher@gmail.com.  Thanks again for your time!
