### PR TITLE
buffer_test: add TestBufferWrite

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -19,8 +19,9 @@ type buffer struct {
 }
 
 var (
-	errReadEmpty = errors.New("read from empty buffer")
-	errWriteFull = errors.New("write on full buffer")
+	errReadEmpty   = errors.New("read from empty buffer")
+	errWriteClosed = errors.New("write on closed buffer")
+	errWriteFull   = errors.New("write on full buffer")
 )
 
 // Read copies bytes from the buffer into p.
@@ -45,7 +46,7 @@ func (b *buffer) Len() int {
 // It is an error to write more data than the buffer can hold.
 func (b *buffer) Write(p []byte) (n int, err error) {
 	if b.closed {
-		return 0, errors.New("closed")
+		return 0, errWriteClosed
 	}
 
 	// Slide existing data to beginning.

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -71,3 +71,84 @@ func TestBufferRead(t *testing.T) {
 		}
 	}
 }
+
+var bufferWriteTests = []struct {
+	buf       buffer
+	write, wn int
+	werr      error
+	wbuf      buffer
+}{
+	{
+		buf: buffer{
+			buf: []byte{},
+		},
+		wbuf: buffer{
+			buf: []byte{},
+		},
+	},
+	{
+		buf: buffer{
+			buf: []byte{1, 'a'},
+		},
+		write: 1,
+		wn:    1,
+		wbuf: buffer{
+			buf: []byte{0, 'a'},
+			w:   1,
+		},
+	},
+	{
+		buf: buffer{
+			buf: []byte{'a', 1},
+			r:   1,
+			w:   1,
+		},
+		write: 2,
+		wn:    2,
+		wbuf: buffer{
+			buf: []byte{0, 0},
+			w:   2,
+		},
+	},
+	{
+		buf: buffer{
+			buf:    []byte{},
+			r:      1,
+			closed: true,
+		},
+		write: 5,
+		werr:  errWriteClosed,
+		wbuf: buffer{
+			buf:    []byte{},
+			r:      1,
+			closed: true,
+		},
+	},
+	{
+		buf: buffer{
+			buf: []byte{},
+		},
+		write: 5,
+		werr:  errWriteFull,
+		wbuf: buffer{
+			buf: []byte{},
+		},
+	},
+}
+
+func TestBufferWrite(t *testing.T) {
+	for i, tt := range bufferWriteTests {
+		n, err := tt.buf.Write(make([]byte, tt.write))
+		if n != tt.wn {
+			t.Errorf("#%d: wrote %d bytes; want %d", i, n, tt.wn)
+			continue
+		}
+		if err != tt.werr {
+			t.Errorf("#%d: error = %v; want %v", i, err, tt.werr)
+			continue
+		}
+		if !reflect.DeepEqual(tt.buf, tt.wbuf) {
+			t.Errorf("#%d: buf = %q; want %q", i, tt.buf, tt.wbuf)
+		}
+	}
+}


### PR DESCRIPTION
Adds test coverage for `buffer.Write()`.  Added a new `errWriteClosed` to facilitate testing.

/cc @bradfitz 