### PR TITLE
Push promise handler

### DIFF
--- a/frame.go
+++ b/frame.go
@@ -770,6 +770,9 @@ func parseHeadersFrame(fh FrameHeader, p []byte) (_ Frame, err error) {
 
 // HeadersFrameParam are the parameters for writing a HEADERS frame.
 type HeadersFrameParam struct {
+	// Write this header as a push promise.
+	PushPromise bool
+
 	// StreamID is the required Stream ID to initiate.
 	StreamID uint32
 	// BlockFragment is part (or all) of a Header Block.
@@ -778,7 +781,7 @@ type HeadersFrameParam struct {
 	// EndStream indicates that the header block is the last that
 	// the endpoint will send for the identified stream. Setting
 	// this flag causes the stream to enter one of "half closed"
-	// states.
+	// states. It is not sent if this write is a push promise.
 	EndStream bool
 
 	// EndHeaders indicates that this frame contains an entire
@@ -791,11 +794,14 @@ type HeadersFrameParam struct {
 	PadLength uint8
 
 	// Priority, if non-zero, includes stream priority information
-	// in the HEADER frame.
+	// in the HEADER frame. It is not sent if this write is a PushPromise.
 	Priority PriorityParam
+
+	// PromiseID is the promised stream if this write is a PushPromise.
+	PromiseID uint32
 }
 
-// WriteHeaders writes a single HEADERS frame.
+// WriteHeaders writes a single HEADERS or PUSH_PROMISE frame.
 //
 // This is a low-level header writing method. Encoding headers and
 // splitting them into any necessary CONTINUATION frames is handled
@@ -811,20 +817,24 @@ func (f *Framer) WriteHeaders(p HeadersFrameParam) error {
 	if p.PadLength != 0 {
 		flags |= FlagHeadersPadded
 	}
-	if p.EndStream {
+	if p.EndStream && !p.PushPromise {
 		flags |= FlagHeadersEndStream
 	}
 	if p.EndHeaders {
 		flags |= FlagHeadersEndHeaders
 	}
-	if !p.Priority.IsZero() {
+	if !p.Priority.IsZero() && !p.PushPromise {
 		flags |= FlagHeadersPriority
 	}
-	f.startWrite(FrameHeaders, flags, p.StreamID)
+	fh := FrameHeaders
+	if p.PushPromise {
+		fh = FramePushPromise
+	}
+	f.startWrite(fh, flags, p.StreamID)
 	if p.PadLength != 0 {
 		f.writeByte(p.PadLength)
 	}
-	if !p.Priority.IsZero() {
+	if !p.Priority.IsZero() && !p.PushPromise {
 		v := p.Priority.StreamDep
 		if !validStreamID(v) && !f.AllowIllegalWrites {
 			return errors.New("invalid dependent stream id")
@@ -835,6 +845,13 @@ func (f *Framer) WriteHeaders(p HeadersFrameParam) error {
 		f.writeUint32(v)
 		f.writeByte(p.Priority.Weight)
 	}
+	if p.PushPromise {
+		if !validStreamID(p.PromiseID) && !f.AllowIllegalWrites {
+			return errStreamID
+		}
+		f.writeUint32(p.PromiseID)
+	}
+
 	f.wbuf = append(f.wbuf, p.BlockFragment...)
 	f.wbuf = append(f.wbuf, padZeros[:p.PadLength]...)
 	return f.endWrite()
@@ -1027,59 +1044,6 @@ func parsePushPromise(fh FrameHeader, p []byte) (_ Frame, err error) {
 	}
 	pp.headerFragBuf = p[:len(p)-int(padLength)]
 	return pp, nil
-}
-
-// PushPromiseParam are the parameters for writing a PUSH_PROMISE frame.
-type PushPromiseParam struct {
-	// StreamID is the required Stream ID to initiate.
-	StreamID uint32
-
-	// PromiseID is the required Stream ID which this
-	// Push Promises
-	PromiseID uint32
-
-	// BlockFragment is part (or all) of a Header Block.
-	BlockFragment []byte
-
-	// EndHeaders indicates that this frame contains an entire
-	// header block and is not followed by any
-	// CONTINUATION frames.
-	EndHeaders bool
-
-	// PadLength is the optional number of bytes of zeros to add
-	// to this frame.
-	PadLength uint8
-}
-
-// WritePushPromise writes a single PushPromise Frame.
-//
-// As with Header Frames, This is the low level call for writing
-// individual frames. Continuation frames are handled elsewhere.
-//
-// It will perform exactly one Write to the underlying Writer.
-// It is the caller's responsibility to not call other Write methods concurrently.
-func (f *Framer) WritePushPromise(p PushPromiseParam) error {
-	if !validStreamID(p.StreamID) && !f.AllowIllegalWrites {
-		return errStreamID
-	}
-	var flags Flags
-	if p.PadLength != 0 {
-		flags |= FlagPushPromisePadded
-	}
-	if p.EndHeaders {
-		flags |= FlagPushPromiseEndHeaders
-	}
-	f.startWrite(FramePushPromise, flags, p.StreamID)
-	if p.PadLength != 0 {
-		f.writeByte(p.PadLength)
-	}
-	if !validStreamID(p.PromiseID) && !f.AllowIllegalWrites {
-		return errStreamID
-	}
-	f.writeUint32(p.PromiseID)
-	f.wbuf = append(f.wbuf, p.BlockFragment...)
-	f.wbuf = append(f.wbuf, padZeros[:p.PadLength]...)
-	return f.endWrite()
 }
 
 // WriteRawFrame writes a raw frame. This can be used to write

--- a/frame_test.go
+++ b/frame_test.go
@@ -540,13 +540,14 @@ func TestWriteGoAway(t *testing.T) {
 }
 
 func TestWritePushPromise(t *testing.T) {
-	pp := PushPromiseParam{
+	pp := HeadersFrameParam{
+		PushPromise:   true,
 		StreamID:      42,
 		PromiseID:     42,
 		BlockFragment: []byte("abc"),
 	}
 	fr, buf := testFramer()
-	if err := fr.WritePushPromise(pp); err != nil {
+	if err := fr.WriteHeaders(pp); err != nil {
 		t.Fatal(err)
 	}
 	const wantEnc = "\x00\x00\x07\x05\x00\x00\x00\x00*\x00\x00\x00*abc"

--- a/h2demo/h2demo.go
+++ b/h2demo/h2demo.go
@@ -213,7 +213,7 @@ func registerHandlers() {
 	})
 	mux2.HandleFunc("/", home)
 	mux2.Handle("/file/gopher.png", fileServer("https://golang.org/doc/gopher/frontpage.png"))
-	mux2.Handle("/file/go.src.tar.gz", fileServer("https://storage.googleapis.com/golang/go1.4rc1.src.tar.gz"))
+	mux2.Handle("/file/go.src.tar.gz", fileServer("https://storage.googleapis.com/golang/go1.4.1.src.tar.gz"))
 	mux2.HandleFunc("/reqinfo", reqInfoHandler)
 	mux2.HandleFunc("/crc32", crcHandler)
 	mux2.HandleFunc("/clockstream", clockStreamHandler)

--- a/h2demo/h2demo.go
+++ b/h2demo/h2demo.go
@@ -287,6 +287,17 @@ func newGopherTilesHandler() http.Handler {
 				return
 			}
 		}
+		cacheBust := time.Now().UnixNano()
+
+		if p, ok := w.(http2.Pusher); ok {
+			for y := 0; y < yt; y++ {
+				for x := 0; x < xt; x++ {
+					path := fmt.Sprintf("/gophertiles?x=%d&y=%d&cachebust=%d&latency=%d", x, y, cacheBust, ms)
+					p.Push("GET", path, nil)
+				}
+			}
+		}
+
 		io.WriteString(w, "<html><body>")
 		fmt.Fprintf(w, "A grid of %d tiled images is below. Compare:<p>", xt*yt)
 		for _, ms := range []int{0, 30, 200, 1000} {
@@ -297,7 +308,6 @@ func newGopherTilesHandler() http.Handler {
 			)
 		}
 		io.WriteString(w, "<p>\n")
-		cacheBust := time.Now().UnixNano()
 		for y := 0; y < yt; y++ {
 			for x := 0; x < xt; x++ {
 				fmt.Fprintf(w, "<img width=%d height=%d src='/gophertiles?x=%d&y=%d&cachebust=%d&latency=%d'>",

--- a/http2.go
+++ b/http2.go
@@ -38,7 +38,7 @@ const (
 
 	// NextProtoTLS is the NPN/ALPN protocol negotiated during
 	// HTTP/2's TLS setup.
-	NextProtoTLS = "h2-14"
+	NextProtoTLS = "h2"
 
 	// http://http2.github.io/http2-spec/#SettingValues
 	initialHeaderTableSize = 4096

--- a/server_test.go
+++ b/server_test.go
@@ -76,7 +76,9 @@ func newServerTester(t testing.TB, handler http.HandlerFunc, opts ...interface{}
 
 	tlsConfig := &tls.Config{
 		InsecureSkipVerify: true,
-		NextProtos:         []string{NextProtoTLS},
+		// The h2-14 is temporary, until curl is updated. (as used by unit tests
+		// in Docker)
+		NextProtos: []string{NextProtoTLS, "h2-14"},
 	}
 
 	onlyServer := false


### PR DESCRIPTION
Improving DanielMorsing's (https://github.com/bradfitz/http2/pull/23) push branch:
  * add concurrency counter and counter logic for push promise streams (curOpenPushStreams and etc);
  * add state transition to stateHalfClosedRemote on push stream when sending headers (writeHeaders());
  * add logic to closeStream(); 
  * minor refactoring.