### PR TITLE
prevent race during resched pump on a closed stream

### DIFF
--- a/server.go
+++ b/server.go
@@ -631,6 +631,9 @@ func (sc *serverConn) serve() {
 		case wm := <-sc.wantWriteFrameCh:
 			sc.writeFrame(wm)
 		case <-sc.wroteFrameCh:
+			if sc.writingFrame != true {
+				panic("internal error: expected to be already writing a frame")
+			}
 			sc.writingFrame = false
 			sc.scheduleFrameWrite()
 		case fg, ok := <-sc.readFrameCh:
@@ -752,6 +755,7 @@ func (sc *serverConn) startFrameWrite(wm frameWriteMsg) {
 	if sc.writingFrame {
 		panic("internal error: can only be writing one frame at a time")
 	}
+	sc.writingFrame = true
 
 	st := wm.stream
 	if st != nil {
@@ -768,7 +772,6 @@ func (sc *serverConn) startFrameWrite(wm frameWriteMsg) {
 		}
 	}
 
-	sc.writingFrame = true
 	sc.needsFrameFlush = true
 	if endsStream(wm.write) {
 		if st == nil {


### PR DESCRIPTION
This is a partial fix for issue #33. There was a race condition caused by sc.writingFrame not being set to true before sc.wroteFrameCh got written to. This meant that the serve select could end up unsetting sc.writingFrame in the middle of writeFrameAsync's execution, which meant two goroutines writing frames at the same time at the same time. Ugh!

It looks like there's still some issues with writeHeaders getting stuck in a select, but that leak only persists for the life of the connection, so not nearly as bad.