### PR TITLE
server: fix leak on writeHeaders during RST_STREAM from client

### DIFF
--- a/writesched.go
+++ b/writesched.go
@@ -239,6 +239,9 @@ func (ws *writeScheduler) forgetStream(id uint32) {
 
 	// But keep it for others later.
 	for i := range q.s {
+		if ch := q.s[i].done; ch != nil {
+			close(ch)
+		}
 		q.s[i] = frameWriteMsg{}
 	}
 	q.s = q.s[:0]


### PR DESCRIPTION
Fixes #45 

Hoping I didn't muck about with too many internals in the test. That was a pain to write.