### PR TITLE
Support for HTTP/1.1 Upgrade ala Section 3.2 of the new soon-to-be RFC

### DIFF
--- a/upgrade.go
+++ b/upgrade.go
@@ -240,24 +240,27 @@ func (m *upgradeMux) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 //
 // Ex usage:
 //
-// http.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
-// 				rw.Header().Set("Content-Type", "text/plain")
-// 				fmt.Fprintf(rw, "response to %v\n", r)
-// })
+// 		http.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+// 			rw.Header().Set("Content-Type", "text/plain")
+// 			fmt.Fprintf(rw, "response to %v\n", r)
+// 		})
 //
-// s := http2.UpgradeServer(&http.Server{Addr:":8080"},nil)
-// s.ListenAndServe()
+// 		s := http2.UpgradeServer(&http.Server{Addr:":8080"},&http2.Server{})
+// 		s.ListenAndServe()
 //
 // NB: Do *not* alter the returned server's Handler, as it is hooked in order to
 // perform the protocol switch. Any changes to uri handling must be made in the
 // "inner" server *before* it is passed to UpgradeServer(). The standard
 // http.DefaultServeMux will always be used as a last resort.
 //
-// NB: Note that HTTP/1.1 requests with bodies (i.e. HTTP POST) are not
-// supported in the initial Upgrade request but will work once the connection
-// is fully HTTP/2. Requests that have content entities will automatically
-// fallback to HTTP/1.1 (the upgrade silently fails but the normal handler
-// is invoked).
+// NB: Note that HTTP/1.1 requests with bodies (i.e. HTTP POST) are not supported
+// in the initial Upgrade request but will work once the connection is fully
+// HTTP/2. Requests that have content entities will automatically fallback to
+// HTTP/1.1 (the upgrade silently fails but the normal handler is invoked). The
+// HTTP/2 spec offers an additional mechanism for performing an upgrade pre-POST
+// by using an "OPTIONS * HTTP/1.1" request w/ upgrade mechanism, but this is not
+// currently possible using net/http w/out wrapping incoming connections and
+// filtering them.
 func UpgradeServer(s *http.Server, conf *Server) *http.Server {
 	if conf == nil {
 		conf = new(Server)

--- a/upgrade.go
+++ b/upgrade.go
@@ -199,6 +199,10 @@ func (m *upgradeMux) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 				}
 			}
 			for k, vals := range r.Header {
+				if k == "Cookie" {
+					sc.req.header.Set(sc.canonicalHeader(k), strings.Join(vals, "; "))
+					continue
+				}
 				if _, ok := ignoreUpgradeHeaders[strings.ToLower(k)]; !ok {
 					for _, v := range vals {
 						if VerboseLogs {

--- a/upgrade.go
+++ b/upgrade.go
@@ -1,0 +1,219 @@
+// Adds HTTP/1.1 Upgrade mode to github.com/bradfitz/http2
+//
+// Upgrade mode works similarly to http2 in tls npn or alpn modes.
+// Use the UpgradeServer() function instead of ConfigureServer to
+// make your standard net/http.Server's http/2 compatible (via
+// the "upgrade" mechanism).
+
+package http2
+
+import (
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+var (
+	http2SettingsHeader  = http.CanonicalHeaderKey("HTTP2-Settings")
+	ignoreUpgradeHeaders = map[string]struct{}{
+		"upgrade":        struct{}{},
+		"connection":     struct{}{},
+		"http2-settings": struct{}{},
+	}
+)
+
+type upgradeMux struct {
+	handler http.Handler
+	srv     *http.Server
+	conf    *Server
+}
+
+type hdr struct {
+	sc       *serverConn
+	key, val string
+}
+
+func (h hdr) String() string {
+	return fmt.Sprintf("{Name:%v, Value:%v}", h.sc.canonicalHeader(h.key), h.val)
+}
+
+func decodeSettings(b []byte) ([]Setting, error) {
+	dst := make([]byte, base64.URLEncoding.DecodedLen(len(b)))
+	n, err := base64.URLEncoding.Decode(dst, b)
+	if err != nil {
+		return nil, err
+	}
+	fh := FrameHeader{
+		valid:  true,
+		Type:   FrameSettings,
+		Length: uint32(n),
+	}
+
+	f, err := parseSettingsFrame(fh, dst[:n])
+	if err == nil {
+		settings := make([]Setting, 0, 4)
+		f.(*SettingsFrame).ForeachSetting(func(s Setting) error {
+			settings = append(settings, s)
+			return nil
+		})
+		return settings, nil
+	}
+	return nil, err
+}
+
+func (m *upgradeMux) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
+	if upg := r.Header.Get("Upgrade"); upg == "h2c-14" || upg == "h2c" {
+		hj, ok := rw.(http.Hijacker)
+		if !ok {
+			panic("cannot hijack this server -- upgrade impossible")
+		}
+		h2sh := r.Header.Get(http2SettingsHeader)
+		if h2sh == "" {
+			http.Error(rw, "missing HTTP2-Settings header", 501)
+			return
+		}
+		settings, err := decodeSettings(bytes.TrimSpace([]byte(h2sh)))
+		if err != nil {
+			http.Error(rw, "invalid HTTP2-Settings header", 501)
+			return
+		}
+
+		for _, connH := range strings.Split(r.Header.Get("Connection"), ",") {
+			connH = strings.TrimSpace(connH)
+			if _, ok := r.Header[http.CanonicalHeaderKey(connH)]; !ok {
+				http.Error(rw, "invalid connection header", 501)
+				return
+			}
+		}
+
+		h := rw.Header()
+
+		for k, _ := range h {
+			h.Del(k)
+		}
+		h.Set("Connection", "Upgrade")
+		h.Set("Upgrade", upg)
+
+		rw.WriteHeader(101)
+		if flusher, ok := rw.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		c, _, err := hj.Hijack()
+		if err != nil {
+			panic(err.Error())
+		}
+		defer c.Close()
+		var sc *serverConn
+		sc, err = m.conf.newConn(m.srv, c, m.handler, settings, func() {
+			defer close(sc.upgradeCh)
+			if sc.maxStreamID < 1 {
+				sc.maxStreamID = 1
+			}
+			st := &stream{
+				id:    1,
+				state: stateHalfClosedRemote,
+			}
+
+			st.cw.Init()
+
+			st.flow.conn = &sc.flow
+			st.flow.add(sc.initialWindowSize)
+			st.inflow.conn = &sc.inflow
+			st.inflow.add(initialWindowSize)
+
+			sc.streams[1] = st
+			sc.curOpenStreams++
+			sc.req = requestParam{
+				stream:           st,
+				method:           r.Method,
+				path:             r.RequestURI,
+				scheme:           r.URL.Scheme,
+				authority:        r.Host,
+				sawRegularHeader: true,
+				header:           make(http.Header),
+			}
+
+			if sc.req.scheme == "" {
+				sc.req.scheme = "http"
+			}
+			if VerboseLogs {
+				sc.vlogf("got header field %+v", &hdr{sc, ":scheme", sc.req.scheme})
+				if sc.req.method != "" {
+					sc.vlogf("got header field %+v", &hdr{sc, ":method", sc.req.method})
+				}
+				if sc.req.path != "" {
+					sc.vlogf("got header field %+v", &hdr{sc, ":path", sc.req.path})
+				}
+				if sc.req.authority != "" {
+					sc.vlogf("got header field %+v", &hdr{sc, ":authority", sc.req.authority})
+				}
+			}
+			for k, vals := range r.Header {
+				if _, ok := ignoreUpgradeHeaders[strings.ToLower(k)]; !ok {
+					for _, v := range vals {
+						if VerboseLogs {
+							sc.vlogf("got header field %+v", &hdr{sc, k, v})
+						}
+						sc.req.header.Add(sc.canonicalHeader(k), v)
+					}
+				}
+			}
+			if err := sc.processHeaderBlockFragment(st, nil, true); err != nil {
+				sc.vlogf("error processing header %v", err)
+			}
+		})
+		if err == nil {
+			m.conf.handleConn(m.srv, c, m.handler, sc)
+		}
+	} else {
+		m.handler.ServeHTTP(rw, r)
+	}
+}
+
+// UpgradeServer operates similarly to ConfigureServer() with the exception that
+// it returns a clone copy of the original server that will be used to
+// exclusively serve HTTP/1.1 and HTTP/1.0 requests. The "HTTP/2 Configured"
+// server passed to UpgradeServer() should not be modified once this call has
+// been made, nor should it actively be listening for new connections.
+//
+// When an existing HTTP/1.1 connection requests an upgrade to h2c or h2c-14 mode,
+// the connection will be hijacked from the "clone server" (as returned by
+// UpgradeServer() and handed off to the internal http2 configured server.
+//
+// Ex usage:
+//
+// http.HandleFunc("/", func(rw http.ResponseWriter, r *http.Request) {
+// 				rw.Header().Set("Content-Type", "text/plain")
+// 				fmt.Fprintf(rw, "response to %v\n", r)
+// })
+//
+// s := http2.UpgradeServer(&http.Server{Addr:":8080"},nil)
+// s.ListenAndServe()
+//
+// NB: Do *not* alter the returned server's Handler, as it is hooked in order to
+// perform the protocol switch. Any changes to uri handling must be made in the
+// "inner" server *before* it is passed to UpgradeServer(). The standard
+// http.DefaultServeMux will always be used as a last resort.
+func UpgradeServer(s *http.Server, conf *Server) *http.Server {
+	if conf == nil {
+		conf = new(Server)
+	}
+
+	handler := s.Handler
+	if handler == nil {
+		handler = http.DefaultServeMux
+	}
+
+	ConfigureServer(s, conf)
+	h1s := new(http.Server)
+	*h1s = *s
+	h1s.Handler = &upgradeMux{
+		handler: handler,
+		srv:     s,
+		conf:    conf,
+	}
+
+	return h1s
+}

--- a/upgrade.go
+++ b/upgrade.go
@@ -203,7 +203,7 @@ func (m *upgradeMux) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 					sc.req.header.Set(sc.canonicalHeader(k), strings.Join(vals, "; "))
 					continue
 				}
-				if _, ok := ignoreUpgradeHeaders[strings.ToLower(k)]; !ok {
+				if _, ok := ignoreUpgradeHeaders[lowerHeader(k)]; !ok {
 					for _, v := range vals {
 						if VerboseLogs {
 							sc.vlogf("got header field %+v", &hdr{sc, k, v})

--- a/upgrade_test.go
+++ b/upgrade_test.go
@@ -1,0 +1,130 @@
+// unit tests for http/1.1 -> http/2 upgrading (Section 3.2)
+
+package http2
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type testUpgradeMode int
+
+const (
+	testUpgradeNoTLS testUpgradeMode = iota
+	testUpgradeTLSOnly
+	testUpgradeDualTLS
+)
+
+func TestUpgradeWithCurl(t *testing.T)     { testUpgradeWithCurl(t, testUpgradeNoTLS, false) }
+func TestUpgradeTLSWithCurl(t *testing.T)  { testUpgradeWithCurl(t, testUpgradeTLSOnly, true) }
+func TestUpgradeDualWithCurl(t *testing.T) { testUpgradeWithCurl(t, testUpgradeDualTLS, true) }
+
+func testUpgradeWithCurl(t *testing.T, mode testUpgradeMode, lenient bool) {
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping Docker test when not on Linux; requires --net which won't work with boot2docker anyway")
+	}
+	requireCurl(t)
+	const msg = "Hello from curl!\n"
+	var ts2 *httptest.Server
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Foo", "Bar")
+		w.Header().Set("Client-Proto", r.Proto)
+		io.WriteString(w, msg)
+	})
+
+	ts := httptest.NewUnstartedServer(handler)
+	switch mode {
+	case testUpgradeNoTLS:
+		ts.TLS = nil
+	default:
+		ts2 = httptest.NewUnstartedServer(handler)
+		ts2.TLS = nil
+	}
+	wrapped := UpgradeServer(ts.Config, &Server{
+		PermitProhibitedCipherSuites: lenient,
+	})
+	modes := make([]testUpgradeMode, 0, 2)
+	switch mode {
+	case testUpgradeNoTLS:
+		modes = append(modes, mode)
+		ts.Config = wrapped
+		ts.Start()
+		t.Logf("Running test server for curl to hit at: %s", ts.URL)
+	case testUpgradeDualTLS:
+		modes = append(modes, testUpgradeNoTLS)
+		fallthrough
+	default:
+		modes = append(modes, testUpgradeTLSOnly)
+		ts2.Config = wrapped
+		ts.TLS = ts.Config.TLSConfig // the httptest.Server has its own copy of this TLS config
+		ts.StartTLS()
+		ts2.Start()
+		defer ts2.Close()
+		t.Logf("Running test server for curl to hit at: %s and %s", ts.URL, ts2.URL)
+	}
+	defer ts.Close()
+	defer func() { testHookOnConn = nil }()
+	for _, mode := range modes {
+		var gotConn int32
+
+		testHookOnConn = func() { atomic.StoreInt32(&gotConn, 1) }
+
+		T := ts
+		if mode == testUpgradeNoTLS && ts2 != nil {
+			T = ts2
+		}
+		container := curl(t, "-D-", "--silent", "--http2", "--insecure", T.URL)
+		defer kill(container)
+		resc := make(chan interface{}, 1)
+		go func() {
+			res, err := dockerLogs(container)
+			if err != nil {
+				resc <- err
+			} else {
+				resc <- res
+			}
+		}()
+		select {
+		case res := <-resc:
+			if err, ok := res.(error); ok {
+				t.Fatal(err)
+			}
+			testDualUpgradeOutput(t, string(res.([]byte)), (T.TLS == nil),
+				"HTTP/2.0 200",
+				"foo:Bar",
+				"client-proto:HTTP/2",
+				msg)
+		case <-time.After(3 * time.Second):
+			t.Errorf("timeout waiting for curl")
+		}
+
+		if atomic.LoadInt32(&gotConn) == 0 {
+			t.Error("never saw an http2 connection")
+		}
+	}
+}
+
+func testDualUpgradeOutput(t *testing.T, out string, isUpgrade bool, must ...string) {
+	if isUpgrade {
+		if !strings.HasPrefix(out, "HTTP/1.1 101 Switching Protocols") {
+			t.Error("didn't see prefix 'HTTP/1.1 101 Switching Protocols'")
+			t.Logf("Got: %s", out)
+		}
+		if !strings.Contains(out, "Upgrade: h2c") {
+			t.Error("didn't see HTTP/1.1 Upgrade header")
+			t.Logf("Got: %s", out)
+		}
+	}
+	for _, s := range must {
+		if !strings.Contains(out, s) {
+			t.Errorf("didn't see %q", s)
+			t.Logf("Got: %s", out)
+		}
+	}
+}


### PR DESCRIPTION
The following PR adds support for HTTP/1.1 upgrading ala Section 3.2.

The public interface for this is quite similar to `ConfigureServer`:

    var h2srv *http.Server
    var conf *http2.Server
    http2.UpgradeServer(h2srv, conf).ListenAndServe()

Internally this is performed by cloning `h2serv` before calling `http2.ConfigureServer()` and hooking its handler. When a request is detected which meets the upgrade requirements (Connection, Upgrade and HTTP2-Settings headers), the settings payload is decoded, the HTTP/1.1 portion of the upgrade is finalized, the connection is flushed and then hijacked. Finally, the hijacked connection is passed off to http2's `handleConn`.

In order to facilitate injection of a hijacked net.Conn into http2's state machine some minor changes to server.go were made:

1. `handleConn()` was refactored slightly by adding a new func: `newConn()` which takes an optional pre-state []Setting slice and an upgrade callback function.
1. A new member was added to the `serverConn` struct: a single-use upgrade channel which returns  a func() that will be called once all settings frames have been ack'd. This callback is used to mock the original HTTP/1.1 request as a header frame payload on the half-closed stream id 1 (as per the spec). A final call to `processHeaderBlockFragment()` triggers downstream application request processing as per usual.

NOTE: Because the spec includes the dubious requirement that any request entity bodies must be read in-full before the protocol upgrade can begin, any attempts to transmit a request body are detected and will result in a silent failure to upgrade and a fallback to HTTP/1.1 handling.

This has been tested using Curl 7.42.0-DEV built against nghttp2/0.7.12-DEV as well as nghttp2 itself. Unit tests are provided which require docker & gohttp2/curl (via http2_test.go).