### PR TITLE
buffer_test, transport_test: fix 'go vet' issues

### DIFF
--- a/buffer_test.go
+++ b/buffer_test.go
@@ -148,7 +148,7 @@ func TestBufferWrite(t *testing.T) {
 			continue
 		}
 		if !reflect.DeepEqual(tt.buf, tt.wbuf) {
-			t.Errorf("#%d: buf = %q; want %q", i, tt.buf, tt.wbuf)
+			t.Errorf("#%d: buf = %+v; want %+v", i, tt.buf, tt.wbuf)
 		}
 	}
 }

--- a/transport_test.go
+++ b/transport_test.go
@@ -76,11 +76,11 @@ func TestTransport(t *testing.T) {
 		t.Errorf("Response.Request = %p; want %p", res.Request, req)
 	}
 	if res.TLS == nil {
-		t.Errorf("Response.TLS = nil; want non-nil", res.TLS)
+		t.Error("Response.TLS = nil; want non-nil")
 	}
 	slurp, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		t.Error("Body read: %v", err)
+		t.Errorf("Body read: %v", err)
 	} else if string(slurp) != body {
 		t.Errorf("Body = %q; want %q", slurp, body)
 	}


### PR DESCRIPTION
Fixes an incorrect formatting directive I introduced in my previous PR, and a couple others.