### PR TITLE
frame_test: add TestFrameTypeString

### DIFF
--- a/frame_test.go
+++ b/frame_test.go
@@ -24,6 +24,25 @@ func TestFrameSizes(t *testing.T) {
 	}
 }
 
+func TestFrameTypeString(t *testing.T) {
+	tests := []struct {
+		ft   FrameType
+		want string
+	}{
+		{FrameData, "DATA"},
+		{FramePing, "PING"},
+		{FrameGoAway, "GOAWAY"},
+		{0xf, "UNKNOWN_FRAME_TYPE_15"},
+	}
+
+	for i, tt := range tests {
+		got := tt.ft.String()
+		if got != tt.want {
+			t.Errorf("%d. String(FrameType %d) = %q; want %q", i, int(tt.ft), got, tt.want)
+		}
+	}
+}
+
 func TestWriteRST(t *testing.T) {
 	fr, buf := testFramer()
 	var streamID uint32 = 1<<24 + 2<<16 + 3<<8 + 4


### PR DESCRIPTION
Provides test coverage for `FrameType.String()`, including the previously untested "unknown frame type" case.